### PR TITLE
Fix the bug Popover doesn't show when it's only rendered on visible

### DIFF
--- a/Popover.js
+++ b/Popover.js
@@ -234,6 +234,11 @@ var Popover = React.createClass({
       }
     }
   },
+  componentDidMount() {
+    if (this.props.isVisible) {
+      this.setState({contentSize: {}, isAwaitingShow: true});
+    }
+  },
   _startAnimation({show}) {
     var handler = this.props.startCustomAnimation || this._startDefaultAnimation;
     handler({show, doneCallback: () => this.setState({isTransitioning: false})});


### PR DESCRIPTION
The case:

```
render() {
  return (
    {
      this.state.visible && (
        <Popover
          isVisible={true}
          fromRect={x: 10, y: 10, width: 10, height: 10}>
            <View />
        </Popover>
      )
    }
  )
}
```

In this case, the `Popover` won't show since the `props` never change, and `this.setState({contentSize: {}, isAwaitingShow: true})` will never be called in `componentWillReceiveProps `.

This PR is to fix the bug.